### PR TITLE
Modificações para adição de ms-catalog

### DIFF
--- a/apps/catalog-service/configmap-cache.yaml
+++ b/apps/catalog-service/configmap-cache.yaml
@@ -1,0 +1,8 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: cache-configmap
+data:
+  redis_url: redis://cache-service:6379
+  redis_host: cache-service
+  redis_port: "6379"

--- a/apps/catalog-service/configmap-catalog.yaml
+++ b/apps/catalog-service/configmap-catalog.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 metadata:
   name: catalog-configmap
 data:
-  database_url: postgres://postgres:postgres@ms-database.database.svc.cluster.local:5432/catalog?schema=public
+  database_url: postgres://postgres:mypassword@ms-database.database.svc.cluster.local:5432/catalog?schema=public
   redis_host: cache-service
   redis_port: "6379"
   npm_run_command: npm run start:dev

--- a/apps/catalog-service/configmap-catalog.yaml
+++ b/apps/catalog-service/configmap-catalog.yaml
@@ -1,0 +1,9 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: catalog-configmap
+data:
+  database_url: postgres://postgres:postgres@ms-database.database.svc.cluster.local:5432/catalog?schema=public
+  redis_host: cache-service
+  redis_port: "6379"
+  npm_run_command: npm run start:dev

--- a/apps/catalog-service/deployment-cache.yaml
+++ b/apps/catalog-service/deployment-cache.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cache-service
+  labels:
+    app: cache-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cache-service
+  template:
+    metadata:
+      labels:
+        app: cache-service
+    spec:
+      containers:
+      - name: cache-service
+        image: redis:7.2-alpine3.18
+        ports:
+        - containerPort: 6379
+      resources:
+      limits:
+        memory: "128Mi"
+        cpu: "0.2"
+      requests:
+        memory: "30Mi"
+        cpu: "0.05"
+

--- a/apps/catalog-service/deployment-cache.yaml
+++ b/apps/catalog-service/deployment-cache.yaml
@@ -19,11 +19,11 @@ spec:
         image: redis:7.2-alpine3.18
         ports:
         - containerPort: 6379
-      resources:
-      limits:
-        memory: "128Mi"
-        cpu: "0.2"
-      requests:
-        memory: "30Mi"
-        cpu: "0.05"
+        resources:
+          limits:
+            memory: "128Mi"
+            cpu: "0.2"
+          requests:
+            memory: "30Mi"
+            cpu: "0.05"
 

--- a/apps/catalog-service/deployment-catalog.yaml
+++ b/apps/catalog-service/deployment-catalog.yaml
@@ -42,9 +42,9 @@ spec:
               key: npm_run_command
         resources:
           limits:
-            memory: "256Mi"
-            cpu: "0.25"
+            memory: "280Mi"
+            cpu: "0.35"
           requests:
-            memory: "130Mi"
-            cpu: "0.1"
+            memory: "180Mi"
+            cpu: "0.2"
 

--- a/apps/catalog-service/deployment-catalog.yaml
+++ b/apps/catalog-service/deployment-catalog.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ms-catalog
+  labels:
+    app: ms-catalog
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ms-catalog
+  template:
+    metadata:
+      labels:
+        app: ms-catalog
+    spec:
+      containers:
+      - name: ms-catalog
+        image: marcoschalet/catalog-service:v1.0.0
+        ports:
+        - containerPort: 3000
+        env:
+        - name: DATABASE_URL
+          valueFrom:
+            configMapKeyRef:
+              name: catalog-configmap
+              key: database_url
+        - name: REDIS_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: catalog-configmap
+              key: redis_host
+        - name: REDIS_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: catalog-configmap
+              key: redis_port
+        - name: NPM_RUN_COMMAND
+          valueFrom:
+            configMapKeyRef:
+              name: catalog-configmap
+              key: npm_run_command
+        resources:
+          limits:
+            memory: "256Mi"
+            cpu: "0.25"
+          requests:
+            memory: "130Mi"
+            cpu: "0.1"
+

--- a/apps/catalog-service/deployment-catalog.yaml
+++ b/apps/catalog-service/deployment-catalog.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: ms-catalog
-        image: marcoschalet/catalog-service:v1.0.0
+        image: marcoschalet/catalog-service:v1.0.1
         ports:
         - containerPort: 3000
         env:

--- a/apps/catalog-service/ingress.yaml
+++ b/apps/catalog-service/ingress.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: catalog-ingress
+  labels:
+    app: catalog
+  annotations:
+    konghq.com/plugins: rate-limiting
+spec:
+  ingressClassName: kong
+  rules:
+  - http:
+      paths:
+      - path: /deals
+        pathType: Prefix
+        backend:
+          service:
+            name: ms-catalog
+            port:
+              number: 80
+      - path: /all
+        pathType: Prefix
+        backend:
+          service:
+            name: ms-catalog
+            port:
+              number: 80

--- a/apps/catalog-service/service-cache.yaml
+++ b/apps/catalog-service/service-cache.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cache-service
+  labels:
+    run: cache-service
+spec:
+  ports:
+  - port: 6379
+    targetPort: 6379
+    protocol: TCP
+  selector:
+    app: cache-service

--- a/apps/catalog-service/service-catalog.yaml
+++ b/apps/catalog-service/service-catalog.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ms-catalog
+  labels:
+    run: ms-catalog
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: 3000
+    protocol: TCP
+  selector:
+    app: ms-catalog

--- a/config/argocd-catalog-app.yaml
+++ b/config/argocd-catalog-app.yaml
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/marcosChalet/infra-sisdis.git
-    targetRevision: develop
+    targetRevision: HEAD
     path: apps/catalog-service
   destination:
     server: https://kubernetes.default.svc

--- a/config/argocd-catalog-app.yaml
+++ b/config/argocd-catalog-app.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: catalog
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/marcosChalet/infra-sisdis.git
+    targetRevision: develop
+    path: apps/catalog-service
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: catalog
+  syncPolicy:
+    syncOptions:
+    - CreateNamespace=true
+    automated:
+      prune: true
+      allowEmpty: true
+      selfHeal: true


### PR DESCRIPTION
### Adição do serviço `ms-catalog` e cache com Redis.

Este pull request introduz o serviço `ms-catalog` no ambiente Kubernetes, gerenciado pelo ArgoCD. As principais modificações incluídas neste PR são:

1. **Adição do serviço `ms-catalog` e serviço de `cache` no Kubernetes:**
  Os arquivos YAML necessários para implantar o serviço ms-catalog foram adicionados ao diretório apps/catalog-service/*

2. **Configuração do argocd para entrega contínua**
  Os arquivos YAML necessários para implantar cache foram adicionados ao diretório config/argocd-catalog-app.yaml.

3. **Ajuste de imagem com fix de bug**
  A imagem foi atualizada da versão 1.0.0 para 1.0.1. Com isso não é mais necessário executar a migração do prisma manualmente dentro do ***pod***.